### PR TITLE
Modified to allow changes to the existing StorageCluster

### DIFF
--- a/deployer/deploy.sh
+++ b/deployer/deploy.sh
@@ -22,9 +22,16 @@ osds=$((${QUOTA_COUNT:-1} * 3))
 
 echo "Quota count: ${QUOTA_COUNT} -- OSD count: ${osds}"
 
+#-- The path mapped to StorageCluster configmap used for overriding.
+overridePath="/sc-override/storagecluster.yml"
+
 #-- Patch the OSD count into the StorageCluster & apply it
+#-- If config map containing StorageCluster exists, apply it. 
+#-- Else, apply the default StorageCluster.
 while true; do
-    sed "s/STORAGE_NODES/${osds}/" storagecluster.yml | \
+    storageClusterPath="storagecluster.yml"
+    [ -f $overridePath ] && storageClusterPath=$overridePath
+    sed "s/STORAGE_NODES/${osds}/" $storageClusterPath | \
       kubectl -n openshift-storage apply -f -
     sleep 60
 done

--- a/patcher/csv_fragment.yml
+++ b/patcher/csv_fragment.yml
@@ -30,4 +30,12 @@ spec:
                     name: deployer
                     image: quay.io/johnstrunk/ocs-osd-deployer:latest
                     imagePullPolicy: Always
+                    volumeMounts:
+                      - mountPath: /sc-override
+                        name: config-volume
                 serviceAccountName: ocs-osd-deployer
+                volumes:
+                  - configMap:
+                      name: sc-config
+                      optional: true
+                    name: config-volume


### PR DESCRIPTION
**Description**

New (fine-tuned) StorageCluster is fetched from the configmap

- User with cluster admin access creates a configmap called `storagecluster` with new StorageCluster yaml in openshift-storage namespace. 

     `kubectl create configmap storagecluster --from-file storagecluster.yml`

- The ocs-osd-deployer pod fetches the configmap for applying StorageCluster if exists. If not, existing StorageCluster is applied.

Signed-off-by: kesavan <kvellalo@redhat.com>