### PR TITLE
Modify rbac permissions and service account

### DIFF
--- a/bundle/manifests/ocs-osd-deployer.clusterserviceversion.yaml
+++ b/bundle/manifests/ocs-osd-deployer.clusterserviceversion.yaml
@@ -50,7 +50,7 @@ spec:
           - subjectaccessreviews
           verbs:
           - create
-        serviceAccountName: default
+        serviceAccountName: ocs-osd-deployer
       deployments:
       - name: ocs-osd-controller-manager
         spec:
@@ -95,6 +95,7 @@ spec:
                   requests:
                     cpu: 100m
                     memory: 20Mi
+              serviceAccountName: ocs-osd-deployer
               terminationGracePeriodSeconds: 10
       permissions:
       - rules:
@@ -158,7 +159,7 @@ spec:
           - patch
           - update
           - watch
-        serviceAccountName: default
+        serviceAccountName: ocs-osd-deployer
     strategy: deployment
   installModes:
   - supported: false

--- a/bundle/manifests/ocs-osd-deployer.clusterserviceversion.yaml
+++ b/bundle/manifests/ocs-osd-deployer.clusterserviceversion.yaml
@@ -39,26 +39,6 @@ spec:
       clusterPermissions:
       - rules:
         - apiGroups:
-          - ocs.openshift.io
-          resources:
-          - managedocs
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
-          - ocs.openshift.io
-          resources:
-          - managedocs/status
-          verbs:
-          - get
-          - patch
-          - update
-        - apiGroups:
           - authentication.k8s.io
           resources:
           - tokenreviews
@@ -145,6 +125,39 @@ spec:
           verbs:
           - create
           - patch
+        - apiGroups:
+          - ocs.openshift.io
+          resources:
+          - managedocs
+          - managedocs/finalizers
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ocs.openshift.io
+          resources:
+          - managedocs/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - ocs.openshift.io
+          resources:
+          - storageclusters
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
         serviceAccountName: default
     strategy: deployment
   installModes:

--- a/bundle/manifests/ocs-osd-deployer_v1_serviceaccount.yaml
+++ b/bundle/manifests/ocs-osd-deployer_v1_serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  name: ocs-osd-deployer

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -42,3 +42,4 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
       terminationGracePeriodSeconds: 10
+      serviceAccountName: deployer

--- a/config/rbac/auth_proxy_role_binding.yaml
+++ b/config/rbac/auth_proxy_role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: proxy-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: deployer
   namespace: system

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -3,6 +3,7 @@ resources:
 - role_binding.yaml
 - leader_election_role.yaml
 - leader_election_role_binding.yaml
+- service_account.yaml
 # Comment the following 4 lines if you want to disable
 # the auth proxy (https://github.com/brancz/kube-rbac-proxy)
 # which protects your /metrics endpoint.

--- a/config/rbac/leader_election_role_binding.yaml
+++ b/config/rbac/leader_election_role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: leader-election-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: deployer
   namespace: system

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -1,15 +1,17 @@
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   creationTimestamp: null
   name: manager-role
+  namespace: system
 rules:
 - apiGroups:
   - ocs.openshift.io
   resources:
   - managedocs
+  - managedocs/finalizers
   verbs:
   - create
   - delete
@@ -26,3 +28,15 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - ocs.openshift.io
+  resources:
+  - storageclusters
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -1,10 +1,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
   name: manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: manager-role
 subjects:
 - kind: ServiceAccount

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: manager-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: deployer
   namespace: system

--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: deployer
+  namespace: system

--- a/controllers/managedocs_controller.go
+++ b/controllers/managedocs_controller.go
@@ -47,8 +47,10 @@ type ManagedOCSReconciler struct {
 	managedOCS *v1.ManagedOCS
 }
 
-// +kubebuilder:rbac:groups=ocs.openshift.io,resources=managedocs,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=ocs.openshift.io,resources=managedocs/status,verbs=get;update;patch
+// Add necessary rbac permissions for managedocs finalizer in order to set blockOwnerDeletion.
+// +kubebuilder:rbac:groups=ocs.openshift.io,namespace=system,resources={managedocs,managedocs/finalizers},verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=ocs.openshift.io,namespace=system,resources=managedocs/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=ocs.openshift.io,namespace=system,resources=storageclusters,verbs=get;list;watch;create;update;patch;delete
 
 // SetupWithManager TODO
 func (r *ManagedOCSReconciler) SetupWithManager(mgr ctrl.Manager) error {


### PR DESCRIPTION
**Description** 
This PR consists of following changes

- Add necessary rbac permissions.
- Modify to role based access.
- Modify service account from `default` to `ocs-osd-deployer `

Signed-off-by: kesavan <kvellalo@redhat.com>