### PR TITLE
[WIP] adding Managed-OCS status

### DIFF
--- a/bundle/manifests/ocs-osd-deployer.clusterserviceversion.yaml
+++ b/bundle/manifests/ocs-osd-deployer.clusterserviceversion.yaml
@@ -88,6 +88,12 @@ spec:
                       fieldPath: metadata.namespace
                 image: ocs-osd-deployer:latest
                 name: manager
+                readinessProbe:
+                  httpGet:
+                    path: /readyz
+                    port: 8081
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
                 resources:
                   limits:
                     cpu: 100m

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -33,6 +33,7 @@ import (
 
 	ocsv1 "github.com/openshift/ocs-operator/pkg/apis"
 	v1 "github.com/openshift/ocs-osd-deployer/api/v1alpha1"
+	"github.com/openshift/ocs-osd-deployer/utils"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -80,10 +81,15 @@ var _ = BeforeSuite(func(done Done) {
 	})
 	Expect(err).ToNot(HaveOccurred())
 
+	// Starting the Readiness Server to be checked by the readiness probe.
+	rdySrvr := utils.NewReadinessServer(ctrl.Log.WithName("Readiness Server"))
+	go rdySrvr.StartReadinessServer()
+
 	err = (&ManagedOCSReconciler{
-		Client: k8sManager.GetClient(),
-		Log:    ctrl.Log.WithName("controllers").WithName("ManagedOCS"),
-		Scheme: scheme.Scheme,
+		Client:  k8sManager.GetClient(),
+		Log:     ctrl.Log.WithName("controllers").WithName("ManagedOCS"),
+		Scheme:  scheme.Scheme,
+		RdySrvr: rdySrvr,
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/utils/readiness.go
+++ b/utils/readiness.go
@@ -1,0 +1,84 @@
+// Defines an HTTP server that reports the readiness of the ocs-osd-operator,
+// and helper functions to Set/Unset its readiness state.
+// For this to work, ensure the following is added to the Deployment definition
+// in the CSV:
+//                readinessProbe:
+//                  httpGet:
+//                    path: /readyz
+//                    port: 8081
+//                  initialDelaySeconds: 5
+//                  periodSeconds: 10
+
+package utils
+
+import (
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/go-logr/logr"
+)
+
+const (
+	PortStr = ":8081"
+)
+
+type ReadinessServer struct {
+	log           logr.Logger
+	operatorReady bool
+	lastUpdated   time.Time
+	sync.Mutex
+}
+
+func NewReadinessServer(log logr.Logger) *ReadinessServer {
+	return &ReadinessServer{
+		log: log,
+	}
+}
+
+func (r *ReadinessServer) StartReadinessServer() {
+	http.HandleFunc("/readyz", func(w http.ResponseWriter, req *http.Request) {
+		r.log.Info("readiness is being probed")
+		r.Lock()
+		operatorReady := r.operatorReady
+		lastUpdated := r.lastUpdated
+		r.Unlock()
+		// Readiness logic is defined here.
+		// From k8s documentation:
+		// "Any code greater than or equal to 200 and less than 400 indicates success."
+		// [indicates that the deployment is ready]
+		// "Any other code indicates failure."
+		// [indicates that the deployment is not ready]
+		if operatorReady {
+			w.WriteHeader(200)
+			r.log.Info("operator is ready")
+		} else {
+			w.WriteHeader(418)
+			r.log.Info("operator is not ready")
+		}
+		// For testing purposes, writting a timestamp in the body of the response
+		// This will be used to track when the readiness was last updated.
+		w.Write([]byte(lastUpdated.Format(time.StampMicro)))
+	})
+
+	r.log.Info("starting readiness server")
+	err := http.ListenAndServe(PortStr, nil)
+	if err != nil {
+		r.log.Error(err, "error occurred in readiness server")
+	}
+}
+
+func (r *ReadinessServer) SetReady() {
+	r.Lock()
+	r.operatorReady = true
+	r.lastUpdated = time.Now()
+	r.Unlock()
+}
+
+func (r *ReadinessServer) UnsetReady(reason string) {
+	r.Lock()
+	r.operatorReady = false
+	r.lastUpdated = time.Now()
+	r.Unlock()
+	r.log.Info(reason)
+}


### PR DESCRIPTION
As an OCM add-on, the ocs-osd-operator needs a way to communicate its
status to OCM. OCM is currently limited to using the CSV status of the
add-on, which it gets every 8 minutes through OLM telemetry. In order to
controll when the operator is reported as installed, a readiness probe
was added, along with logic in the controller to only report the
operator as ready when the cluster is in its desired state. Currently,
the desired state is a StorageCluster in a "Ready" phase.