### PR TITLE
using defer to guarantee that status is updated at the end of reconcile.

### DIFF
--- a/bundle/manifests/ocs-osd-deployer.clusterserviceversion.yaml
+++ b/bundle/manifests/ocs-osd-deployer.clusterserviceversion.yaml
@@ -9,9 +9,6 @@ metadata:
           "kind": "ManagedOCS",
           "metadata": {
             "name": "managedocs-sample"
-          },
-          "spec": {
-            "foo": "bar"
           }
         }
       ]


### PR DESCRIPTION
We would like to ensure the reconcile loop always updates the CR's
status. As it was written prior, this required the developer to remember
not to modify or return before running that logic in the reconcile
loop. With the use of defer, this requirement is now explicitly
expressed in the code. As reconcile returns, the function defined within
the defer statement is called and will update the status. This will run
no matter when reconcile returns.