### PR TITLE
Adding readiness probe

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,15 +15,20 @@ COPY api/ api/
 COPY controllers/ controllers/
 COPY utils/ utils/
 COPY templates/ templates/
+COPY readinessProbe/ readinessProbe/
 
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
+
+# Build readiness probe binary
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o readinessServer readinessProbe/main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --from=builder /workspace/manager .
+COPY --from=builder /workspace/readinessServer .
 USER nonroot:nonroot
 
 ENTRYPOINT ["/manager"]

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -42,5 +42,27 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: ADDON_NAME
+      - name: readiness-server
+        command:
+        - /readinessServer
+        image: controller:latest
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 100m
+            memory: 30Mi
+          requests:
+            cpu: 10m
+            memory: 2Mi
+        env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
       terminationGracePeriodSeconds: 10
       serviceAccountName: deployer

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/onsi/ginkgo v1.12.1
 	github.com/onsi/gomega v1.10.1
 	github.com/openshift/ocs-operator v0.0.1-alpha1.0.20201201172124-0811c33c21b2
+	k8s.io/api v0.19.3
 	k8s.io/apimachinery v0.19.3
 	k8s.io/client-go v12.0.0+incompatible
 	sigs.k8s.io/controller-runtime v0.6.3

--- a/readinessProbe/main.go
+++ b/readinessProbe/main.go
@@ -1,0 +1,71 @@
+// Description: This program creates a web server to verify if the managedOCS
+//              resource is ready. It is used as a readiness probe by the
+//              ocs-osd-deployer operator. For this to be set up, the following
+//              sidecar should be added to the manager CSV:
+//      - name: readinessServer
+//        command:
+//        - /readinessServer
+//        image: ocs-osd-deployer:latest
+//        readinessProbe:
+//          httpGet:
+//            path: /readyz
+//            port: 8081
+//          initialDelaySeconds: 5
+//          periodSeconds: 10
+package main
+
+import (
+	"fmt"
+	"os"
+
+	ocsv1 "github.com/openshift/ocs-operator/pkg/apis"
+	v1 "github.com/openshift/ocs-osd-deployer/api/v1alpha1"
+	"github.com/openshift/ocs-osd-deployer/readinessProbe/readiness"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+func main() {
+	// Setup logging
+	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
+	log := ctrl.Log.WithName("readiness")
+
+	// Setup client options
+	var options client.Options
+
+	// The readiness must have these schemes to deserialize the k8s objects
+	options.Scheme = runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(options.Scheme))
+	utilruntime.Must(ocsv1.AddToScheme(options.Scheme))
+	utilruntime.Must(v1.AddToScheme(options.Scheme))
+
+	k8sClient, err := client.New(config.GetConfigOrDie(), options)
+	if err != nil {
+		log.Error(err, "error creating client")
+		os.Exit(1)
+	}
+
+	namespace, found := os.LookupEnv(readiness.NamespaceEnvVarName)
+	if !found {
+		log.Error(fmt.Errorf("%q not set", readiness.NamespaceEnvVarName), "error in environment variables")
+		os.Exit(2)
+	}
+
+	managedOCSResource := types.NamespacedName{
+		Name:      "managedocs",
+		Namespace: namespace,
+	}
+
+	log.Info("starting HTTP server...")
+	err = readiness.RunServer(k8sClient, managedOCSResource, log)
+	if err != nil {
+		log.Error(err, "server error")
+	}
+	log.Info("HTTP server terminated.")
+}

--- a/readinessProbe/readiness/server.go
+++ b/readinessProbe/readiness/server.go
@@ -1,0 +1,56 @@
+package readiness
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/go-logr/logr"
+	v1 "github.com/openshift/ocs-osd-deployer/api/v1alpha1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	listenAddr          string = ":8081"
+	readinessPath       string = "/readyz/"
+	NamespaceEnvVarName string = "NAMESPACE"
+)
+
+func isReady(client client.Client, managedOCSResource types.NamespacedName) (bool, error) {
+
+	var managedOCS v1.ManagedOCS
+
+	if err := client.Get(context.Background(), managedOCSResource, &managedOCS); err != nil {
+		return false, err
+	}
+
+	ready := managedOCS.Status.Components.StorageCluster.State == v1.ComponentReady
+	return ready, nil
+}
+
+func RunServer(client client.Client, managedOCSResource types.NamespacedName, log logr.Logger) error {
+
+	// Readiness probe is defined here.
+	// From k8s documentation:
+	// "Any code greater than or equal to 200 and less than 400 indicates success."
+	// [indicates that the deployment is ready]
+	// "Any other code indicates failure."
+	// [indicates that the deployment is not ready]
+	http.HandleFunc(readinessPath, func(httpw http.ResponseWriter, req *http.Request) {
+		ready, err := isReady(client, managedOCSResource)
+
+		if err != nil {
+			log.Error(err, "error checking readiness\n")
+			httpw.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		if ready {
+			httpw.WriteHeader(http.StatusOK)
+		} else {
+			httpw.WriteHeader(http.StatusServiceUnavailable)
+		}
+	})
+
+	return http.ListenAndServe(listenAddr, nil)
+}

--- a/readinessProbe/readiness/server_test.go
+++ b/readinessProbe/readiness/server_test.go
@@ -1,0 +1,78 @@
+package readiness
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	v1 "github.com/openshift/ocs-osd-deployer/api/v1alpha1"
+	utils "github.com/openshift/ocs-osd-deployer/testutils"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("ManagedOCS Readiness Probe", func() {
+	// Define utility constants for object names and testing timeouts/durations and intervals.
+	const (
+		timeout  = time.Second * 10
+		duration = time.Second * 10
+		interval = time.Millisecond * 250
+	)
+
+	When("managedocs reports its components as \"not ready\"", func() {
+		BeforeEach(func() {
+			ctx := context.Background()
+
+			managedOCS := &v1.ManagedOCS{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      ManagedOCSName,
+					Namespace: TestNamespace,
+				},
+				Status: v1.ManagedOCSStatus{
+					Components: v1.ComponentStatusMap{
+						StorageCluster: v1.ComponentStatus{
+							State: v1.ComponentPending,
+						},
+					},
+				},
+			}
+
+			Expect(k8sClient.Create(ctx, managedOCS)).Should(Succeed())
+
+			utils.WaitForResource(k8sClient, ctx, managedOCS, timeout, interval)
+		})
+
+		It("should cause the readiness logic to report \"not ready\"", func() {
+			status, err := utils.ProbeReadiness()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(status).To(Equal(http.StatusServiceUnavailable))
+		})
+	})
+
+	When("managedocs reports its components as \"ready\"", func() {
+		BeforeEach(func() {
+			ctx := context.Background()
+			managedOCS := &v1.ManagedOCS{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      ManagedOCSName,
+					Namespace: TestNamespace,
+				},
+			}
+
+			// This test expects the ManagedOCS resource to already have been made.
+			err := k8sClient.Get(ctx, utils.GetResourceKey(managedOCS), managedOCS)
+			Expect(err).ToNot(HaveOccurred())
+
+			managedOCS.Status.Components.StorageCluster.State = v1.ComponentReady
+
+			Expect(k8sClient.Status().Update(ctx, managedOCS)).Should(Succeed())
+		})
+
+		It("should cause the readiness logic to report \"ready\"", func() {
+			status, err := utils.ProbeReadiness()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(status).To(Equal(http.StatusOK))
+		})
+	})
+})

--- a/readinessProbe/readiness/suite_test.go
+++ b/readinessProbe/readiness/suite_test.go
@@ -1,0 +1,100 @@
+/*
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package readiness
+
+import (
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	ocsv1 "github.com/openshift/ocs-operator/pkg/apis"
+	v1 "github.com/openshift/ocs-osd-deployer/api/v1alpha1"
+	// +kubebuilder:scaffold:imports
+)
+
+// These tests use Ginkgo (BDD-style Go testing framework). Refer to
+// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
+const (
+	ManagedOCSName = "test-managedocs"
+	TestNamespace  = "default"
+)
+
+var cfg *rest.Config
+var k8sClient client.Client
+var testEnv *envtest.Environment
+
+func TestAPIs(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecsWithDefaultAndCustomReporters(t,
+		"Readiness Probe Suite",
+		[]Reporter{printer.NewlineReporter{}})
+}
+
+var _ = BeforeSuite(func(done Done) {
+	logf.SetLogger(zap.LoggerTo(GinkgoWriter, true))
+
+	By("bootstrapping test environment")
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths: []string{
+			filepath.Join("..", "..", "config", "crd", "bases"),
+			filepath.Join("..", "..", "misc"),
+		},
+	}
+
+	var err error
+	cfg, err = testEnv.Start()
+	Expect(err).ToNot(HaveOccurred())
+	Expect(cfg).ToNot(BeNil())
+
+	// Setup client options
+	var options client.Options
+
+	// The readiness must have these schemes to deserialize the k8s objects
+	options.Scheme = runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(options.Scheme))
+	utilruntime.Must(ocsv1.AddToScheme(options.Scheme))
+	utilruntime.Must(v1.AddToScheme(options.Scheme))
+
+	// Client to be use by the test code, using a non cached client
+	k8sClient, err = client.New(cfg, options)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(k8sClient).ToNot(BeNil())
+
+	go RunServer(k8sClient, types.NamespacedName{Name: ManagedOCSName, Namespace: TestNamespace}, ctrl.Log.WithName("readiness"))
+
+	close(done)
+}, 60)
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+	err := testEnv.Stop()
+	Expect(err).ToNot(HaveOccurred())
+})

--- a/testutils/utils.go
+++ b/testutils/utils.go
@@ -1,0 +1,45 @@
+package testutils
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func WaitForResource(k8sClient client.Client, ctx context.Context, obj runtime.Object, timeout time.Duration, interval time.Duration) {
+	key, err := client.ObjectKeyFromObject(obj)
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
+
+	EventuallyWithOffset(1, func() bool {
+		err := k8sClient.Get(ctx, key, obj)
+		return err == nil
+	}, timeout, interval).Should(BeTrue())
+}
+
+func EnsureNoResource(k8sClient client.Client, ctx context.Context, obj runtime.Object, timeout time.Duration, interval time.Duration) {
+	key, err := client.ObjectKeyFromObject(obj)
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
+
+	EventuallyWithOffset(1, func() bool {
+		err := k8sClient.Get(ctx, key, obj)
+		return err == nil
+	}, timeout, interval).Should(BeFalse())
+}
+
+func GetResourceKey(obj runtime.Object) client.ObjectKey {
+	key, err := client.ObjectKeyFromObject(obj)
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
+	return key
+}
+
+func ProbeReadiness() (int, error) {
+	resp, err := http.Get("http://localhost:8081/readyz")
+	if err != nil {
+		return 0, err
+	}
+	return resp.StatusCode, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -259,6 +259,7 @@ gopkg.in/tomb.v1
 # gopkg.in/yaml.v2 v2.3.0
 gopkg.in/yaml.v2
 # k8s.io/api v0.19.3 => k8s.io/api v0.19.3
+## explicit
 k8s.io/api/admission/v1beta1
 k8s.io/api/admissionregistration/v1
 k8s.io/api/admissionregistration/v1beta1


### PR DESCRIPTION
As an OCM add-on, the ocs-osd-operator needs a way to communicate its
status to OCM. OCM is currently limited to using the CSV status of the
add-on, which it gets every 8 minutes through OLM telemetry. In order to
control when the operator is reported as installed, a readiness probe
was added, along with logic in the controller to only report the
operator as ready when all of its components are in their desired state.