### PR TITLE
Add changes to display warn logs without stack trace

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/onsi/gomega v1.10.1
 	github.com/openshift/ocs-operator v0.0.1-alpha1.0.20201201172124-0811c33c21b2
 	github.com/operator-framework/api v0.1.1
+	go.uber.org/zap v1.14.1
 	k8s.io/api v0.19.3
 	k8s.io/apimachinery v0.19.3
 	k8s.io/client-go v12.0.0+incompatible

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 
+	"go.uber.org/zap/zapcore"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -78,7 +79,7 @@ func main() {
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.Parse()
 
-	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
+	ctrl.SetLogger(zap.New(zap.UseDevMode(true), zap.StacktraceLevel(zapcore.ErrorLevel)))
 
 	envVars, err := readEnvVars()
 	if err != nil {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -164,6 +164,7 @@ go.uber.org/atomic
 # go.uber.org/multierr v1.5.0
 go.uber.org/multierr
 # go.uber.org/zap v1.14.1
+## explicit
 go.uber.org/zap
 go.uber.org/zap/buffer
 go.uber.org/zap/internal/bufferpool


### PR DESCRIPTION
The StacktraceLevel is set to Error level to avoid stack trace for warn logs

Signed-off-by: kesavan <kvellalo@redhat.com>