### PR TITLE
Fix prometheus template for access and linking the alertmanagerr

### DIFF
--- a/templates/prometheus.go
+++ b/templates/prometheus.go
@@ -21,8 +21,11 @@ const PrometheusTemplate = `
 apiVersion: monitoring.coreos.com/v1
 kind: Prometheus
 spec:
-  serviceAccountName: ocs-monitoring
+  serviceAccountName: prometheus-k8s
   serviceMonitorSelector:
+    matchLabels:
+      app: managed-ocs
+  ruleSelector:
     matchLabels:
       app: managed-ocs
   podMonitorSelector:
@@ -33,4 +36,9 @@ spec:
       cpu: 1
       memory: 200Mi
   enableAdminAPI: false
+  alerting:
+    alertmanagers:
+    - namespace: openshift-storage
+      name: alertmanager-operated
+      port: web
 `


### PR DESCRIPTION
Modified to use prometheus service account and add changes to link the required alertmanager

Fixes : #33 
Signed-off-by: kesavan <kvellalo@redhat.com>