### PR TITLE
Read the number of prometheus/alertmanager ready replicas from the backing statefulsets status

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -32,6 +32,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - monitoring.coreos.com
   resources:
   - alertmanagers


### PR DESCRIPTION
Prometheus-operator does not fill the prometheus and alertmanager resources status section (see https://github.com/prometheus-operator/prometheus-operator/issues/887).

Given that, the next best place to get a status on the readiness of these resources is the status section of the backing statefulsets.