### PR TITLE
Replace all text based resource templates with API struct instances

### DIFF
--- a/controllers/managedocs_controller.go
+++ b/controllers/managedocs_controller.go
@@ -19,10 +19,11 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"gopkg.in/yaml.v2"
 	"strconv"
 	"strings"
 	"time"
+
+	"gopkg.in/yaml.v2"
 
 	opv1a1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -87,9 +88,8 @@ type ManagedOCSReconciler struct {
 	alertmanager             *promv1.Alertmanager
 	pagerdutySecret          *corev1.Secret
 	alertmanagerConfigSecret *corev1.Secret
-	// alertmanagerConfig *promv1a1.AlertmanagerConfig
-	namespace         string
-	reconcileStrategy v1.ReconcileStrategy
+	namespace                string
+	reconcileStrategy        v1.ReconcileStrategy
 }
 
 // Add necessary rbac permissions for managedocs finalizer in order to set blockOwnerDeletion.
@@ -459,7 +459,7 @@ func (r *ManagedOCSReconciler) reconcileStorageCluster() error {
 		// Handle only strict mode reconciliation
 		if r.reconcileStrategy == v1.ReconcileStrategyStrict {
 			// Get an instance of the desired state
-			desired := utils.ObjectFromTemplate(templates.StorageClusterTemplate, r.Scheme).(*ocsv1.StorageCluster)
+			desired := templates.StorageClusterTemplate.DeepCopy()
 			if err := r.updateStorageClusterFromAddonParamsSecret(desired); err != nil {
 				return err
 			}
@@ -540,7 +540,7 @@ func (r *ManagedOCSReconciler) reconcilePrometheus() error {
 			return err
 		}
 
-		desired := utils.ObjectFromTemplate(templates.PrometheusTemplate, r.Scheme).(*promv1.Prometheus)
+		desired := templates.PrometheusTemplate.DeepCopy()
 		r.prometheus.ObjectMeta.Labels = map[string]string{monLabelKey: monLabelValue}
 		r.prometheus.Spec = desired.Spec
 
@@ -560,7 +560,7 @@ func (r *ManagedOCSReconciler) reconcileAlertmanager() error {
 			return err
 		}
 
-		desired := utils.ObjectFromTemplate(templates.AlertmanagerTemplate, r.Scheme).(*promv1.Alertmanager)
+		desired := templates.AlertmanagerTemplate.DeepCopy()
 		r.alertmanager.ObjectMeta.Labels = map[string]string{monLabelKey: monLabelValue}
 		r.alertmanager.Spec = desired.Spec
 

--- a/templates/alertmanager.go
+++ b/templates/alertmanager.go
@@ -16,14 +16,16 @@ limitations under the License.
 
 package templates
 
+import (
+	promv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
+)
+
 // AlertmanagerTemplate is the template that serves as the base for the Alert Manager deployed by the operator
-const AlertmanagerTemplate = `
-apiVersion: monitoring.coreos.com/v1
-kind: Alertmanager
-spec:
-  replicas: 3
-  alertmanagerConfigSelector:
-    matchLabels:
-      app: managed-ocs
-  configSecret: managed-ocs-alertmanager-config-secret
-`
+var _3 = int32(3)
+
+var AlertmanagerTemplate = promv1.Alertmanager{
+	Spec: promv1.AlertmanagerSpec{
+		Replicas:     &_3,
+		ConfigSecret: "managed-ocs-alertmanager-config-secret",
+	},
+}

--- a/templates/storagecluster.go
+++ b/templates/storagecluster.go
@@ -16,69 +16,105 @@ limitations under the License.
 
 package templates
 
+import (
+	ocsv1 "github.com/openshift/ocs-operator/pkg/apis/ocs/v1"
+	rook "github.com/rook/rook/pkg/apis/rook.io/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
 // StorageClusterTemplate is the template that serves as the base for the storage clsuter deployed by the operator
-const StorageClusterTemplate = `
-apiVersion: ocs.openshift.io/v1
-kind: StorageCluster
-spec:
-  # The label selector is used to select only the worker nodes for
-  # both labeling and scheduling.
-  labelSelector:
-    matchExpressions:
-      - key: node-role.kubernetes.io/worker
-        operator: Exists
-      - key: node-role.kubernetes.io/infra
-        operator: DoesNotExist
-  manageNodes: false
-  monPVCTemplate:
-    spec:
-      storageClassName: gp2
-      accessModes:
-        - ReadWriteOnce
-  resources:
-    mds:
-      limits:
-        cpu: 3000m
-        memory: 8Gi
-      requests:
-        cpu: 1000m
-        memory: 8Gi
-    mgr:
-      limits:
-        cpu: 1000m
-        memory: 3Gi
-      requests:
-        cpu: 1000m
-        memory: 3Gi
-    mon:
-      limits:
-        cpu: 1000m
-        memory: 2Gi
-      requests:
-        cpu: 1000m
-        memory: 2Gi
-  storageDeviceSets:
-    - name: default
-      count: 1
-      dataPVCTemplate:
-        spec:
-          storageClassName: gp2
-          accessModes:
-            - ReadWriteOnce
-          volumeMode: Block
-          resources:
-            requests:
-              storage: 1Ti
-      placement: {}
-      portable: true
-      replica: 3
-      resources:
-        limits:
-          cpu: 2000m
-          memory: 5Gi
-        requests:
-          cpu: 1000m
-          memory: 5Gi
-  multiCloudGateway:
-    reconcileStrategy: "ignore"
-`
+var gp2 = "gp2"
+var volumeModeBlock = corev1.PersistentVolumeBlock
+
+var StorageClusterTemplate = ocsv1.StorageCluster{
+	Spec: ocsv1.StorageClusterSpec{
+		// The label selector is used to select only the worker nodes for
+		// both labeling and scheduling.
+		LabelSelector: &metav1.LabelSelector{
+			MatchExpressions: []metav1.LabelSelectorRequirement{{
+				Key:      "node-role.kubernetes.io/worker",
+				Operator: metav1.LabelSelectorOpExists,
+			}, {
+				Key:      "node-role.kubernetes.io/infra",
+				Operator: metav1.LabelSelectorOpDoesNotExist,
+			}},
+		},
+		ManageNodes: false,
+		MonPVCTemplate: &corev1.PersistentVolumeClaim{
+			Spec: corev1.PersistentVolumeClaimSpec{
+				StorageClassName: &gp2,
+				AccessModes: []corev1.PersistentVolumeAccessMode{
+					corev1.ReadWriteOnce,
+				},
+			},
+		},
+		Resources: map[string]corev1.ResourceRequirements{
+			"mds": {
+				Limits: corev1.ResourceList{
+					"cpu":    resource.MustParse("3000m"),
+					"memory": resource.MustParse("8Gi"),
+				},
+				Requests: corev1.ResourceList{
+					"cpu":    resource.MustParse("1000m"),
+					"memory": resource.MustParse("8Gi"),
+				},
+			},
+			"mgr": {
+				Limits: corev1.ResourceList{
+					"cpu":    resource.MustParse("1000m"),
+					"memory": resource.MustParse("3Gi"),
+				},
+				Requests: corev1.ResourceList{
+					"cpu":    resource.MustParse("1000m"),
+					"memory": resource.MustParse("3Gi"),
+				},
+			},
+			"mon": {
+				Limits: corev1.ResourceList{
+					"cpu":    resource.MustParse("1000m"),
+					"memory": resource.MustParse("2Gi"),
+				},
+				Requests: corev1.ResourceList{
+					"cpu":    resource.MustParse("1000m"),
+					"memory": resource.MustParse("2Gi"),
+				},
+			},
+		},
+		StorageDeviceSets: []ocsv1.StorageDeviceSet{{
+			Name:  "default",
+			Count: 1,
+			DataPVCTemplate: corev1.PersistentVolumeClaim{
+				Spec: corev1.PersistentVolumeClaimSpec{
+					StorageClassName: &gp2,
+					AccessModes: []corev1.PersistentVolumeAccessMode{
+						corev1.ReadWriteOnce,
+					},
+					VolumeMode: &volumeModeBlock,
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							"storage": resource.MustParse("1Ti"),
+						},
+					},
+				},
+			},
+			Placement: rook.Placement{},
+			Portable:  true,
+			Replica:   3,
+			Resources: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					"cpu":    resource.MustParse("2000m"),
+					"memory": resource.MustParse("5Gi"),
+				},
+				Requests: corev1.ResourceList{
+					"cpu":    resource.MustParse("1000m"),
+					"memory": resource.MustParse("5Gi"),
+				},
+			},
+		}},
+		MultiCloudGateway: &ocsv1.MultiCloudGatewaySpec{
+			ReconcileStrategy: "ignore",
+		},
+	},
+}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -18,22 +18,7 @@ package utils
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/serializer"
 )
-
-// ObjectFromTemplate returns a runtime object based on a text yaml/json string template
-func ObjectFromTemplate(text string, scheme *runtime.Scheme) runtime.Object {
-	// Decode text (yaml/json) to kube api object
-	deserializer := serializer.NewCodecFactory(scheme).UniversalDeserializer()
-	obj, group, err := deserializer.Decode([]byte(text), nil, nil)
-	if err != nil {
-		panic(err)
-	}
-	// not sure if really needed, but set it anyway
-	obj.GetObjectKind().SetGroupVersionKind(*group)
-	return obj
-}
 
 // Contains checks whether a string is contained within a slice
 func Contains(slice []string, s string) bool {


### PR DESCRIPTION
The change bring with it the following benefits:
- Type safety, specifically in the cases where the API structure changes upon vendor upgrade.
- Prevent mistakes that are not caught by schema validation (e.g. introduction of fields that are not specified in the API schema).
- A reconcile iteration will execute faster as we do not deserialize yaml strings anymore

Signed-off-by: nb-ohad <mitrani.ohad@gmail.com>