### PR TITLE
Pass deployer namespace to alertmanager endpoint

### DIFF
--- a/controllers/managedocs_controller.go
+++ b/controllers/managedocs_controller.go
@@ -563,6 +563,7 @@ func (r *ManagedOCSReconciler) reconcilePrometheus() error {
 		desired := templates.PrometheusTemplate.DeepCopy()
 		r.prometheus.ObjectMeta.Labels = map[string]string{monLabelKey: monLabelValue}
 		r.prometheus.Spec = desired.Spec
+		r.prometheus.Spec.Alerting.Alertmanagers[0].Namespace = r.namespace
 
 		return nil
 	})


### PR DESCRIPTION
Adding namespace in the alertmanager endpoint instructs the prometheus to look for the endpoint only inside the provided namespace

Signed-off-by: kesavan <kvellalo@redhat.com>