### PR TITLE
Add update permission for secrets

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -31,6 +31,7 @@ rules:
   - create
   - get
   - list
+  - update
   - watch
 - apiGroups:
   - apps

--- a/controllers/managedocs_controller.go
+++ b/controllers/managedocs_controller.go
@@ -103,7 +103,7 @@ type ManagedOCSReconciler struct {
 // +kubebuilder:rbac:groups="monitoring.coreos.com",namespace=system,resources={alertmanagers,prometheuses},verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="monitoring.coreos.com",namespace=system,resources=prometheusrules,verbs=get;list;watch;create;update;patch
 // +kubebuilder:rbac:groups="monitoring.coreos.com",namespace=system,resources={podmonitors,servicemonitors},verbs=get;list;watch;update;patch
-// +kubebuilder:rbac:groups="",namespace=system,resources=secrets,verbs=create;get;list;watch
+// +kubebuilder:rbac:groups="",namespace=system,resources=secrets,verbs=create;get;list;watch;update
 // +kubebuilder:rbac:groups=operators.coreos.com,namespace=system,resources={subscriptions,clusterserviceversions},verbs=get;list;watch;delete
 // +kubebuilder:rbac:groups="apps",namespace=system,resources=statefulsets,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;watch


### PR DESCRIPTION
This allows the deployer to update the alertmanager config secret when pagerduty or deadmans snitch secret is updated

Signed-off-by: kesavan <kvellalo@redhat.com>