### PR TITLE
Configured Alert Manager to add SOP links to alerts sent to PagerDuty.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ all: manager readinessServer
 export_env_vars:
 export NAMESPACE = openshift-storage
 export ADDON_NAME = ocs-converged
+export SOP_ENDPOINT = "https://red-hat-storage.github.io/ocs-sop/sop/OSD/{{ .GroupLabels.alertname }}.html"
 
 # Run tests
 ENVTEST_ASSETS_DIR = $(shell pwd)/testbin

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -42,6 +42,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: ADDON_NAME
+        - name: SOP_ENDPOINT
       - name: readiness-server
         command:
         - /readinessServer

--- a/main.go
+++ b/main.go
@@ -44,8 +44,9 @@ import (
 )
 
 const (
-	namespaceEnvVarName = "NAMESPACE"
-	addonNameEnvVarName = "ADDON_NAME"
+	namespaceEnvVarName   = "NAMESPACE"
+	addonNameEnvVarName   = "ADDON_NAME"
+	sopEndpointEnvVarName = "SOP_ENDPOINT"
 )
 
 var (
@@ -118,6 +119,7 @@ func main() {
 		DeployerSubscriptionName:     fmt.Sprintf("addon-%v", addonName),
 		PagerdutySecretName:          fmt.Sprintf("%v-pagerduty", addonName),
 		DeadMansSnitchSecretName:     fmt.Sprintf("%v-deadmanssnitch", addonName),
+		SOPEndpoint:                  envVars[sopEndpointEnvVarName],
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "Unable to create controller", "controller", "ManagedOCS")
 		os.Exit(1)
@@ -164,6 +166,12 @@ func readEnvVars() (map[string]string, error) {
 		return nil, fmt.Errorf("%s environment variable must be set", addonNameEnvVarName)
 	}
 	envVars[addonNameEnvVarName] = val
+
+	val, found = os.LookupEnv(sopEndpointEnvVarName)
+	if !found {
+		return nil, fmt.Errorf("%s environment variable must be set", sopEndpointEnvVarName)
+	}
+	envVars[sopEndpointEnvVarName] = val
 
 	return envVars, nil
 }


### PR DESCRIPTION
This was tested by deploying the add-on on an OCM cluster, firing off an alert, then checking PagerDuty for the alert received.

![image](https://user-images.githubusercontent.com/6934052/118706117-fffc0680-b7e6-11eb-8dfe-816e6ddfe524.png)
