### PR TITLE
Fix ocs dependency to use the latest z stream version

### DIFF
--- a/config/metadata/dependencies.yaml
+++ b/config/metadata/dependencies.yaml
@@ -6,4 +6,4 @@ dependencies:
 - type: olm.package
   value:
     packageName: ocs-operator
-    version: "4.7.0"
+    version: ">4.7.0 <4.8.0"


### PR DESCRIPTION
When a new z stream version is released, previous version is removed from the registry. This fix will pick the latest available z stream version

Signed-off-by: kesavan <kvellalo@redhat.com>