### PR TITLE
Integrate SendGrid to support customer email notification

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ export_env_vars:
 export NAMESPACE = openshift-storage
 export ADDON_NAME = ocs-converged
 export SOP_ENDPOINT = https://red-hat-storage.github.io/ocs-sop/sop/OSD/{{ .GroupLabels.alertname }}.html
+export ALERT_SMTP_FROM_ADDR = noreply-test@test.com
 
 # Run tests
 ENVTEST_ASSETS_DIR = $(shell pwd)/testbin
@@ -56,9 +57,11 @@ readinessServer: fmt vet
 # Run against the configured Kubernetes cluster in ~/.kube/config
 run: generate fmt vet manifests export_env_vars
 	kubectl create namespace ${NAMESPACE} --dry-run=client -o yaml | kubectl apply -f -
-	kubectl create secret generic addon-${ADDON_NAME}-parameters -n ${NAMESPACE} --from-literal=size=1 --from-literal=enable-mcg=false --dry-run=client -oyaml | kubectl apply -f -
+	kubectl create secret generic addon-${ADDON_NAME}-parameters -n ${NAMESPACE} --from-literal size=1 --from-literal enable-mcg=false --dry-run=client -oyaml | kubectl apply -f -
 	kubectl create secret generic ${ADDON_NAME}-pagerduty -n ${NAMESPACE} --from-literal PAGERDUTY_KEY="test-key" --dry-run=client -oyaml | kubectl apply -f -
 	kubectl create secret generic ${ADDON_NAME}-deadmanssnitch -n ${NAMESPACE} --from-literal SNITCH_URL="https://test-url" --dry-run=client -oyaml | kubectl apply -f -
+	kubectl create secret generic ${ADDON_NAME}-smtp -n ${NAMESPACE} --from-literal host="smtp.sendgrid.net" --from-literal password="test-key" --from-literal port="587" \
+	--from-literal username="apikey" --dry-run=client -oyaml | kubectl apply -f -
 	kubectl create configmap rook-ceph-operator-config -n ${NAMESPACE} --dry-run=client -oyaml | kubectl apply -f -
 	echo -e "apiVersion: operators.coreos.com/v1alpha1" \
 	      "\nkind: ClusterServiceVersion" \

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -43,6 +43,7 @@ spec:
               fieldPath: metadata.namespace
         - name: ADDON_NAME
         - name: SOP_ENDPOINT
+        - name: ALERT_SMTP_FROM_ADDR
       - name: readiness-server
         command:
         - /readinessServer

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -56,6 +56,7 @@ const (
 	testAddonParamsSecretName                  = "test-addon-secret"
 	testPagerdutySecretName                    = "test-pagerduty-secret"
 	testDeadMansSnitchSecretName               = "test-deadmanssnitch-secret"
+	testSMTPSecretName                         = "test-smtp-secret"
 	testAddonConfigMapName                     = "test-addon-configmap"
 	testAddonConfigMapDeleteLabelKey           = "test-addon-configmap-delete-label-key"
 	testSubscriptionName                       = "test-subscription"
@@ -122,6 +123,7 @@ var _ = BeforeSuite(func(done Done) {
 		DeployerSubscriptionName:     testSubscriptionName,
 		PagerdutySecretName:          testPagerdutySecretName,
 		DeadMansSnitchSecretName:     testDeadMansSnitchSecretName,
+		SMTPSecretName:               testSMTPSecretName,
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
@@ -179,6 +181,15 @@ var _ = BeforeSuite(func(done Done) {
 	managedOCS.Name = managedOCSName
 	managedOCS.Namespace = testPrimaryNamespace
 	Expect(k8sClient.Create(ctx, managedOCS)).ShouldNot(HaveOccurred())
+
+	// Create the rook ceph operator config map
+	rookConfigMap := &corev1.ConfigMap{}
+	rookConfigMap.Name = "rook-ceph-operator-config"
+	rookConfigMap.Namespace = testPrimaryNamespace
+	rookConfigMap.Data = map[string]string{
+		"test-key": "test-value",
+	}
+	Expect(k8sClient.Create(ctx, rookConfigMap)).ShouldNot(HaveOccurred())
 
 	close(done)
 }, 60)

--- a/main.go
+++ b/main.go
@@ -45,9 +45,10 @@ import (
 )
 
 const (
-	namespaceEnvVarName   = "NAMESPACE"
-	addonNameEnvVarName   = "ADDON_NAME"
-	sopEndpointEnvVarName = "SOP_ENDPOINT"
+	namespaceEnvVarName         = "NAMESPACE"
+	addonNameEnvVarName         = "ADDON_NAME"
+	sopEndpointEnvVarName       = "SOP_ENDPOINT"
+	alertSMTPFromAddrEnvVarName = "ALERT_SMTP_FROM_ADDR"
 )
 
 var (
@@ -120,7 +121,9 @@ func main() {
 		DeployerSubscriptionName:     fmt.Sprintf("addon-%v", addonName),
 		PagerdutySecretName:          fmt.Sprintf("%v-pagerduty", addonName),
 		DeadMansSnitchSecretName:     fmt.Sprintf("%v-deadmanssnitch", addonName),
+		SMTPSecretName:               fmt.Sprintf("%v-smtp", addonName),
 		SOPEndpoint:                  envVars[sopEndpointEnvVarName],
+		AlertSMTPFrom:                envVars[alertSMTPFromAddrEnvVarName],
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "Unable to create controller", "controller", "ManagedOCS")
 		os.Exit(1)
@@ -153,26 +156,19 @@ func getUnrestrictedClient() client.Client {
 }
 
 func readEnvVars() (map[string]string, error) {
-	envVars := map[string]string{}
-
-	val, found := os.LookupEnv(namespaceEnvVarName)
-	if !found {
-		return nil, fmt.Errorf("%s environment variable must be set", namespaceEnvVarName)
-
+	envVars := map[string]string{
+		namespaceEnvVarName:         "",
+		addonNameEnvVarName:         "",
+		sopEndpointEnvVarName:       "",
+		alertSMTPFromAddrEnvVarName: "",
 	}
-	envVars[namespaceEnvVarName] = val
-
-	val, found = os.LookupEnv(addonNameEnvVarName)
-	if !found {
-		return nil, fmt.Errorf("%s environment variable must be set", addonNameEnvVarName)
+	for envVarName := range envVars {
+		val, found := os.LookupEnv(envVarName)
+		if !found {
+			return nil, fmt.Errorf("%s environment variable must be set", envVarName)
+		}
+		envVars[envVarName] = val
 	}
-	envVars[addonNameEnvVarName] = val
-
-	val, found = os.LookupEnv(sopEndpointEnvVarName)
-	if !found {
-		return nil, fmt.Errorf("%s environment variable must be set", sopEndpointEnvVarName)
-	}
-	envVars[sopEndpointEnvVarName] = val
 
 	return envVars, nil
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -18,6 +18,7 @@ package utils
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"strings"
 )
 
 // Contains checks whether a string is contained within a slice
@@ -49,4 +50,9 @@ func AddLabel(obj metav1.Object, key string, value string) {
 		obj.SetLabels(labels)
 	}
 	labels[key] = value
+}
+
+// GetRegexMatcher converts list of alerts to regex matcher
+func GetRegexMatcher(alerts []string) string {
+	return "^" + strings.Join(alerts, "$|^") + "$"
 }


### PR DESCRIPTION
The customer email ids are fecthed during the addon install and relevant storage alerts are sent to the target address via alertmanager routes

Signed-off-by: kesavan <kvellalo@redhat.com>