### PR TITLE
Updating prometheus rule for DMS.

### DIFF
--- a/controllers/managedocs_controller.go
+++ b/controllers/managedocs_controller.go
@@ -638,6 +638,17 @@ func (r *ManagedOCSReconciler) reconcileDMSPrometheusRule() error {
 		}
 
 		desired := templates.DMSPrometheusRuleTemplate.DeepCopy()
+
+		for _, group := range desired.Spec.Groups {
+			if group.Name == "snitch-alert" {
+				for _, rule := range group.Rules {
+					if rule.Alert == "DeadMansSnitch" {
+						rule.Labels["namespace"] = r.namespace
+					}
+				}
+			}
+		}
+
 		r.dmsRule.Spec = desired.Spec
 
 		return nil

--- a/controllers/managedocs_controller_test.go
+++ b/controllers/managedocs_controller_test.go
@@ -897,7 +897,7 @@ var _ = Describe("ManagedOCS controller", func() {
 			})
 		})
 		When("the dms prometheus rule resource is deleted", func() {
-			It("should create a new dms prometheus rule in the namespace", func() {
+			It("should create a new dms prometheus rule in the namespace with expected labels", func() {
 				// Ensure prometheus rule existed to begin with
 				utils.WaitForResource(k8sClient, ctx, dmsPromRuleTemplate.DeepCopy(), timeout, interval)
 
@@ -906,6 +906,13 @@ var _ = Describe("ManagedOCS controller", func() {
 
 				// Wait for the prometheus rule to be recreated
 				utils.WaitForResource(k8sClient, ctx, dmsPromRuleTemplate.DeepCopy(), timeout, interval)
+
+				// Check labels in prometheus rule
+				Expect(k8sClient.Get(ctx, utils.GetResourceKey(&dmsPromRuleTemplate), &dmsPromRuleTemplate)).Should(Succeed())
+
+				Expect(dmsPromRuleTemplate.Spec.Groups[0].Rules[0].Labels["alertname"]).Should(Equal("DeadMansSnitch"))
+				Expect(dmsPromRuleTemplate.Spec.Groups[0].Rules[0].Labels["namespace"]).Should(Equal(testPrimaryNamespace))
+
 			})
 		})
 		When("there is a pod monitor without an ocs-dedicated label", func() {


### PR DESCRIPTION
With the recent changes to Alertmanager's configuration, the DeadMan's
Snitch alert was filtered out and never sent to to the DMS endpoint.
This PR adds the labels needed for alertmanager to forward the message
and enhances an existing test to ensure the expected labels are
configured.

Signed-off-by: Renan Campos <rcampos@redhat.com>