### PR TITLE
Lock ocs-operator version to 4.7.2 and bump deployer to v1.0.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Current Operator version
-VERSION ?= 0.0.1
+VERSION ?= 1.0.0
 # Default bundle image tag
 IMAGE_TAG_BASE ?= controller
 BUNDLE_IMG ?= $(IMAGE_TAG_BASE)-bundle:v$(VERSION)

--- a/config/manifests/bases/ocs-osd-deployer.clusterserviceversion.yaml
+++ b/config/manifests/bases/ocs-osd-deployer.clusterserviceversion.yaml
@@ -17,7 +17,8 @@ spec:
       kind: ManagedOCS
       name: managedocs.ocs.openshift.io
       version: v1alpha1
-  description: Installs and Managed the lifecycle of an OpenShift Container Storage (OCS) instance on an OpenShift dedicated cluster
+  description: Installs and Managed the lifecycle of an OpenShift Container Storage
+    (OCS) instance on an OpenShift dedicated cluster
   displayName: OCS OSD Deployer
   icon:
   - base64data: ""

--- a/config/metadata/dependencies.yaml
+++ b/config/metadata/dependencies.yaml
@@ -6,4 +6,4 @@ dependencies:
 - type: olm.package
   value:
     packageName: ocs-operator
-    version: ">=4.7.0 <4.8.0"
+    version: "4.7.2"


### PR DESCRIPTION
Signed-off-by: nb-ohad <mitrani.ohad@gmail.com>