### PR TITLE
[Bug 1987271] Requeuing ManagedOCS CR upon conflict while uninstall

### DIFF
--- a/controllers/managedocs_controller.go
+++ b/controllers/managedocs_controller.go
@@ -298,6 +298,10 @@ func (r *ManagedOCSReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) 
 	if err != nil {
 		return ctrl.Result{}, err
 	} else if statusErr != nil {
+		if errors.IsConflict(statusErr) {
+			r.Log.Info("Managedocs CR is being updated, requeing in 10 seconds")
+			return ctrl.Result{Requeue: true, RequeueAfter: 10 * time.Second}, nil
+		}
 		return ctrl.Result{}, statusErr
 	} else {
 		return result, nil


### PR DESCRIPTION
While updating the status for the ManagedOCS cr the request is stale and it was causing a panic. This PR attempts to solve the issue by requeuing the request after 10 sec.