### PR TITLE
[Bug 1987271] Refreshing manangedOCS object after deletion is scheduled

### DIFF
--- a/controllers/managedocs_controller.go
+++ b/controllers/managedocs_controller.go
@@ -478,6 +478,14 @@ func (r *ManagedOCSReconciler) reconcilePhases() (reconcile.Result, error) {
 			if err := r.delete(r.managedOCS); err != nil {
 				return ctrl.Result{}, fmt.Errorf("unable to delete managedocs: %v", err)
 			}
+			// Refreshing local managedOCS object after deletion is scheduled
+			// to avoid conflict while updating status
+			if err := r.get(r.managedOCS); err != nil {
+				if !errors.IsNotFound(err) {
+					return ctrl.Result{}, err
+				}
+				r.Log.V(-1).Info("Trying to reload ManagedOCS resource after delete failed, ManagedOCS resource not found")
+			}
 		}
 
 	} else if initiateUninstall {


### PR DESCRIPTION
During uninstall when managedOCS object is scheduled for deletion a stale copy of it remains in local. When managedOCS status is updated it causes a conflict. This PR fixes that by refreshing the local copy of the object before status is updated.
Signed-off-by: kmajumder <kmajumder@redhat.com>