### PR TITLE
Add changes to support downstream image for prometheus and alertamanager

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -44,6 +44,8 @@ spec:
         - name: ADDON_NAME
         - name: SOP_ENDPOINT
         - name: ALERT_SMTP_FROM_ADDR
+        - name: PROMETHEUS_IMAGE
+        - name: ALERTMANAGER_IMAGE
       - name: readiness-server
         command:
         - /readinessServer

--- a/controllers/managedocs_controller.go
+++ b/controllers/managedocs_controller.go
@@ -101,6 +101,8 @@ type ManagedOCSReconciler struct {
 	SMTPSecretName               string
 	SOPEndpoint                  string
 	AlertSMTPFrom                string
+	PrometheusImage              string
+	AlertmanagerImage            string
 
 	ctx                                context.Context
 	managedOCS                         *v1.ManagedOCS
@@ -685,6 +687,10 @@ func (r *ManagedOCSReconciler) reconcilePrometheus() error {
 		r.prometheus.Spec = desired.Spec
 		r.prometheus.Spec.Alerting.Alertmanagers[0].Namespace = r.namespace
 
+		if r.PrometheusImage != "" {
+			r.prometheus.Spec.Image = &r.PrometheusImage
+		}
+
 		return nil
 	})
 	if err != nil {
@@ -761,6 +767,10 @@ func (r *ManagedOCSReconciler) reconcileAlertmanager() error {
 		}
 		r.alertmanager.Spec = desired.Spec
 		utils.AddLabel(r.alertmanager, monLabelKey, monLabelValue)
+
+		if r.AlertmanagerImage != "" {
+			r.alertmanager.Spec.Image = &r.AlertmanagerImage
+		}
 
 		return nil
 	})

--- a/main.go
+++ b/main.go
@@ -50,6 +50,8 @@ const (
 	addonNameEnvVarName         = "ADDON_NAME"
 	sopEndpointEnvVarName       = "SOP_ENDPOINT"
 	alertSMTPFromAddrEnvVarName = "ALERT_SMTP_FROM_ADDR"
+	prometheusImageEnvVarName   = "PROMETHEUS_IMAGE"
+	alertmanagerImageEnvVarName = "ALERTMANAGER_IMAGE"
 )
 
 var (
@@ -126,6 +128,8 @@ func main() {
 		SMTPSecretName:               fmt.Sprintf("%v-smtp", addonName),
 		SOPEndpoint:                  envVars[sopEndpointEnvVarName],
 		AlertSMTPFrom:                envVars[alertSMTPFromAddrEnvVarName],
+		PrometheusImage:              envVars[prometheusImageEnvVarName],
+		AlertmanagerImage:            envVars[alertmanagerImageEnvVarName],
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "Unable to create controller", "controller", "ManagedOCS")
 		os.Exit(1)
@@ -163,6 +167,8 @@ func readEnvVars() (map[string]string, error) {
 		addonNameEnvVarName:         "",
 		sopEndpointEnvVarName:       "",
 		alertSMTPFromAddrEnvVarName: "",
+		prometheusImageEnvVarName:   "",
+		alertmanagerImageEnvVarName: "",
 	}
 	for envVarName := range envVars {
 		val, found := os.LookupEnv(envVarName)


### PR DESCRIPTION
The images of prometheus and alertamanger are overridden based on the downstream images passed as environment variables

Signed-off-by: kesavan <kvellalo@redhat.com>