### PR TITLE
Updated prometheus packagename to deploy downstream prometheus operator

### DIFF
--- a/config/metadata/dependencies.yaml
+++ b/config/metadata/dependencies.yaml
@@ -1,8 +1,8 @@
 dependencies:
 - type: olm.package
   value:
-    packageName: prometheus
-    version: "0.47.0"
+    packageName: ose-prometheus-operator
+    version: "4.8.0"
 - type: olm.package
   value:
     packageName: ocs-operator


### PR DESCRIPTION
Downstream prometheus manifests are maintained along with the addon bundle, this fix is to deploy the maintained downstream prometheus as a dependency

Signed-off-by: kesavan <kvellalo@redhat.com>